### PR TITLE
removed breaking change: equal alias is '=' again

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AutoQueryable &middot; [![NuGet](https://img.shields.io/nuget/v/AutoQueryable.svg?style=flat-square)](https://www.nuget.org/packages/AutoQueryable) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/trenoncourt/AutoQueryable/blob/master/LICENSE)
-> AutoQueryable add auto querying functionality like OData on top of IQueryable with best url practices. It help you to make requests like [http://baseurl/api/products?nameContains=frame&color==red,black](http://baseurl/api/products?nameContains=frame&color==red,black) with no effort.
+> AutoQueryable add auto querying functionality like OData on top of IQueryable with best url practices. It help you to make requests like [http://baseurl/api/products?nameContains=frame&color=red,black](http://baseurl/api/products?nameContains=frame&color=red,black) with no effort.
 
 ## Installing / Getting started
 
@@ -85,7 +85,7 @@ You will get result like:
 By default filters are separated by AND (eg: color=red&color=black is translated by color == red AND color == black)
 
 In a filter, comma separator is used for OR (eg: color=red,black is translated by color == red OR black)
-- Equals '=': [/products?**color==red,black**](/products?color!=green,blue)
+- Equals '=': [/products?**color=red,black**](/products?color!=green,blue)
 - Not Equals '!=': [/products?**color!=green,blue**](/products?color=red,black)
 - Less Than, Greater Than '<', '>': [/products?**productCount\<5**](/products?productCount\<5)
 - Less Than or Equals, Greater Than or equals '<=' [/products?**productCount\<=5**](/products?productCount\<=5)

--- a/src/AutoQueryable/Core/Aliases/ConditionAlias.cs
+++ b/src/AutoQueryable/Core/Aliases/ConditionAlias.cs
@@ -2,7 +2,7 @@
 {
     public static class ConditionAlias
     {
-        public const string Equal = "==";
+        public const string Equal = "=";
         public const string NotEqual = "!=";
         public const string LessThan = "<";
         public const string LessThanOrEqual = "<=";

--- a/test/AutoQueryable.UnitTest/FilterTest.cs
+++ b/test/AutoQueryable.UnitTest/FilterTest.cs
@@ -15,7 +15,7 @@ namespace AutoQueryable.UnitTest
             using (var context = new Mock.AutoQueryableContext())
             {
                 DataInitializer.InitializeSeed(context);
-                var query = (context.Product.AutoQueryable("productid==5") as IEnumerable<dynamic>).ToList();
+                var query = (context.Product.AutoQueryable("productid=5") as IEnumerable<dynamic>).ToList();
                 query.Count.Should().Be(1);
                 var first = query.First();
                 int id = first.GetType().GetProperty("ProductId").GetValue(first);
@@ -29,7 +29,7 @@ namespace AutoQueryable.UnitTest
             using (var context = new Mock.AutoQueryableContext())
             {
                 DataInitializer.InitializeSeed(context);
-                var query = (context.Product.AutoQueryable("productid==3,4,5") as IEnumerable<dynamic>).ToList();
+                var query = (context.Product.AutoQueryable("productid=3,4,5") as IEnumerable<dynamic>).ToList();
                 query.Count.Should().Be(3);
 
                 foreach (var product in query)
@@ -45,7 +45,7 @@ namespace AutoQueryable.UnitTest
             using (var context = new Mock.AutoQueryableContext())
             {
                 DataInitializer.InitializeSeed(context);
-                var query = (context.Product.AutoQueryable("ProductCategory.ProductCategoryId==1") as IEnumerable<dynamic>).ToList();
+                var query = (context.Product.AutoQueryable("ProductCategory.ProductCategoryId=1") as IEnumerable<dynamic>).ToList();
                 query.Count.Should().Be(DataInitializer.ProductSampleCount / 2);
             }
         }
@@ -56,7 +56,7 @@ namespace AutoQueryable.UnitTest
             using (var context = new Mock.AutoQueryableContext())
             {
                 DataInitializer.InitializeSeed(context);
-                var query = (context.Product.AutoQueryable("productid==3&productid==4") as IEnumerable<dynamic>).ToList();
+                var query = (context.Product.AutoQueryable("productid=3&productid=4") as IEnumerable<dynamic>).ToList();
                 query.Count.Should().Be(0);
             }
         }
@@ -67,7 +67,7 @@ namespace AutoQueryable.UnitTest
             using (var context = new Mock.AutoQueryableContext())
             {
                 DataInitializer.InitializeSeed(context);
-                var query = (context.Product.AutoQueryable("productid==3,4&productid==5,6") as IEnumerable<dynamic>).ToList();
+                var query = (context.Product.AutoQueryable("productid=3,4&productid=5,6") as IEnumerable<dynamic>).ToList();
                 query.Count.Should().Be(0);
             }
         }
@@ -78,7 +78,7 @@ namespace AutoQueryable.UnitTest
             using (var context = new Mock.AutoQueryableContext())
             {
                 DataInitializer.InitializeSeed(context);
-                var query = (context.Product.AutoQueryable($"rowguid=={DataInitializer.GuidString}") as IEnumerable<dynamic>).ToList();
+                var query = (context.Product.AutoQueryable($"rowguid={DataInitializer.GuidString}") as IEnumerable<dynamic>).ToList();
                 query.Count.Should().Be(DataInitializer.ProductSampleCount);
                 var first = query.First();
                 Guid id = first.GetType().GetProperty("Rowguid").GetValue(first);
@@ -92,7 +92,7 @@ namespace AutoQueryable.UnitTest
             using (var context = new Mock.AutoQueryableContext())
             {
                 DataInitializer.InitializeSeed(context);
-                var query = (context.Product.AutoQueryable("color==red") as IEnumerable<dynamic>).ToList();
+                var query = (context.Product.AutoQueryable("color=red") as IEnumerable<dynamic>).ToList();
                 query.Count.Should().Be(DataInitializer.ProductSampleCount / 2);
             }
         }
@@ -104,7 +104,7 @@ namespace AutoQueryable.UnitTest
             {
                 DataInitializer.InitializeSeed(context);
 
-                var query = (context.Product.AutoQueryable("color==red,black") as IEnumerable<dynamic>).ToList();
+                var query = (context.Product.AutoQueryable("color=red,black") as IEnumerable<dynamic>).ToList();
                 query.Count.Should().Be(DataInitializer.ProductSampleCount);
             }
         }
@@ -116,7 +116,7 @@ namespace AutoQueryable.UnitTest
             {
                 DataInitializer.InitializeSeed(context);
                 var todayJsonFormated = DateTime.Today.ToString("yyyy-MM-dd");
-                var query = (context.Product.AutoQueryable($"SellStartDate=={todayJsonFormated}") as IEnumerable<dynamic>).ToList();
+                var query = (context.Product.AutoQueryable($"SellStartDate={todayJsonFormated}") as IEnumerable<dynamic>).ToList();
                 query.Count.Should().Be(1);
                 var first = query.First();
                 DateTime sellStartDate = first.GetType().GetProperty("SellStartDate").GetValue(first);
@@ -132,7 +132,7 @@ namespace AutoQueryable.UnitTest
                 DataInitializer.InitializeSeed(context);
                 var todayJsonFormated = DateTime.Today.ToString("yyyy-MM-dd");
                 var todayPlus8HourJsonFormated = DateTime.Today.AddHours(8).ToString("yyyy-MM-ddThh:mm:ss");
-                var query = (context.Product.AutoQueryable($"SellStartDate=={todayJsonFormated},{todayPlus8HourJsonFormated}") as IEnumerable<dynamic>).ToList();
+                var query = (context.Product.AutoQueryable($"SellStartDate={todayJsonFormated},{todayPlus8HourJsonFormated}") as IEnumerable<dynamic>).ToList();
                 query.Count.Should().Be(2);
                 foreach (var product in query)
                 {
@@ -148,7 +148,7 @@ namespace AutoQueryable.UnitTest
             using (var context = new Mock.AutoQueryableContext())
             {
                 DataInitializer.InitializeSeed(context);
-                var query = context.Product.AutoQueryable("SalesOrderDetail.UnitPrice==2") as IEnumerable<dynamic>;
+                var query = context.Product.AutoQueryable("SalesOrderDetail.UnitPrice=2") as IEnumerable<dynamic>;
                 query.Count().Should().Be(1);
             }
         }
@@ -159,7 +159,7 @@ namespace AutoQueryable.UnitTest
             using (var context = new Mock.AutoQueryableContext())
             {
                 DataInitializer.InitializeSeed(context);
-                var query = context.Product.AutoQueryable("SalesOrderDetail.Product.ProductId==1") as IEnumerable<dynamic>;
+                var query = context.Product.AutoQueryable("SalesOrderDetail.Product.ProductId=1") as IEnumerable<dynamic>;
                 query.Count().Should().Be(1);
             }
         }
@@ -170,7 +170,7 @@ namespace AutoQueryable.UnitTest
             using (var context = new Mock.AutoQueryableContext())
             {
                 DataInitializer.InitializeSeed(context);
-                var query = (context.Product.AutoQueryable($"SellStartDate=={DateTime.Today.AddHours(8 * 2).ToString("o")}") as IEnumerable<dynamic>).ToList();
+                var query = (context.Product.AutoQueryable($"SellStartDate={DateTime.Today.AddHours(8 * 2).ToString("o")}") as IEnumerable<dynamic>).ToList();
                 query.Count.Should().Be(1);
                 var first = query.First();
                 int id = first.GetType().GetProperty("ProductId").GetValue(first);


### PR DESCRIPTION
In my last pull request, you noted that the breaking change could be a problem.

I forgot that I already solved the problem by adding a 'Level' to each condition in the FilterMap. Because of this, 'Contains=' for example is checked first, before checking the shorter aliases like '='.

I have changed the code to use '=' as an alias again.

Kr,
Appsum