### PR TITLE
fix: ignore indexer properties

### DIFF
--- a/src/AutoQueryable/Core/Clauses/ClauseHandlers/SelectClauseHandler.cs
+++ b/src/AutoQueryable/Core/Clauses/ClauseHandlers/SelectClauseHandler.cs
@@ -73,7 +73,7 @@ namespace AutoQueryable.Core.Clauses
                     else
                     {
                         // pass non selectable & unselectable properties
-                        if (IsNotSelectableProperty(key) || IsUnselectableProperty(key))
+                        if (IsNotSelectableProperty(key) || IsUnselectableProperty(key) || IsAnIndexerProperty(property))
                             continue;
 
                         var column = new SelectColumn(columnName, key, property.PropertyType);
@@ -144,6 +144,11 @@ namespace AutoQueryable.Core.Clauses
         {
             return _profile?.SelectableProperties != null &&
                    !_profile.SelectableProperties.Contains(key, StringComparer.OrdinalIgnoreCase);
+        }
+
+        private bool IsAnIndexerProperty(PropertyInfo propertyInfo)
+        {
+            return propertyInfo.GetIndexParameters().Length > 0;
         }
 
         public bool CanIncludeAll(string key, int depth)
@@ -218,7 +223,7 @@ namespace AutoQueryable.Core.Clauses
                 var property = _baseType.GetTypeOrGenericType().GetProperties().FirstOrDefault(x =>
                     string.Equals(x.Name.ToLowerInvariant(), columnName.ToLowerInvariant(), StringComparison.Ordinal));
 
-                if (property == null || IsGreaterThanMaxDepth(property, 0))
+                if (property == null || IsGreaterThanMaxDepth(property, 0) || IsAnIndexerProperty(property))
                     continue;
 
                 var column = new SelectColumn(columnName, columnName, property.PropertyType);

--- a/src/AutoQueryable/Core/Extensions/TypeExtensions.cs
+++ b/src/AutoQueryable/Core/Extensions/TypeExtensions.cs
@@ -132,10 +132,11 @@ namespace AutoQueryable.Core.Extensions
             {
                 columns = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
                     .Where(p =>
-                    (p.PropertyType.GetTypeInfo().IsGenericType && p.PropertyType.GetTypeInfo().GetGenericTypeDefinition() == typeof(Nullable<>))
+                    ((p.PropertyType.GetTypeInfo().IsGenericType && p.PropertyType.GetTypeInfo().GetGenericTypeDefinition() == typeof(Nullable<>))
                     || (!p.PropertyType.GetTypeInfo().IsClass && !p.PropertyType.GetTypeInfo().IsGenericType)
                     || p.PropertyType.GetTypeInfo().IsArray
-                    || p.PropertyType == typeof(string)
+                    || p.PropertyType == typeof(string))
+                    && p.GetIndexParameters().Length <= 0
                     )
                     .Select(p => new SelectColumn(p.Name, p.Name, p.PropertyType));
             }

--- a/test/AutoQueryable.UnitTest/Mock/Entities/Product.cs
+++ b/test/AutoQueryable.UnitTest/Mock/Entities/Product.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AutoQueryable.UnitTest.Mock.Entities
 {
@@ -27,6 +28,8 @@ namespace AutoQueryable.UnitTest.Mock.Entities
         public string ThumbnailPhotoFileName { get; set; }
         public Guid Rowguid { get; set; }
         public DateTime ModifiedDate { get; set; }
+        [NotMapped]
+        public string this[string key] { get => Name; set => Name = value; }
 
         public virtual ICollection<SalesOrderDetail> SalesOrderDetail { get; set; }
         public virtual ProductExtension ProductExtension { get; set; }


### PR DESCRIPTION
ignore indexer properties by default in SelectClauseHandler.
add indexer property in product model used by unit tests.
will try to manage indexer properties in a future build

fix #58